### PR TITLE
Add fast mode to skip QR/POD extraction

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,11 @@
 
    <input type="text" id="outputFilename" placeholder="Enter merged file name" value="Merged_Manifest">
 
+   <label style="display:block; text-align:center; margin-bottom:10px;">
+     <input type="checkbox" id="fastMode" checked>
+     Fast mode (skip Tracking and POD)
+   </label>
+
    <div id="controls">
      <button id="merge-btn">Generate Manifest PDF</button>
      <button id="remove-all-btn">Remove All</button>

--- a/script.js
+++ b/script.js
@@ -224,7 +224,7 @@ async function extractQRCodeFromPage(page) {
 }
 
 //  PDF parsing & QR + Transport collection 
-async function extractFromPDF(file) {
+async function extractFromPDF(file, fastMode) {
     const buf = await file.arrayBuffer();
     const pdf = await pdfjsLib.getDocument({
         data: buf
@@ -308,12 +308,14 @@ async function extractFromPDF(file) {
         });
 
         // extract QR
-        const qrUrl = await extractQRCodeFromPage(pg);
-        if (qrUrl) {
-            qrEntries.push({
-                loadingList: currentLoadingList,
-                dataUrl: qrUrl
-            });
+        if (!fastMode) {
+            const qrUrl = await extractQRCodeFromPage(pg);
+            if (qrUrl) {
+                qrEntries.push({
+                    loadingList: currentLoadingList,
+                    dataUrl: qrUrl
+                });
+            }
         }
     }
 }
@@ -332,13 +334,14 @@ async function generatePDF() {
     qrEntries = [];
     transportEntries = [];
 
+    const fastMode = document.getElementById('fastMode')?.checked ?? true;
     const files = Array.from(fileInput.files);
     if (!files.length) {
         alert('Select at least one PDF');
         return;
     }
     for (let f of files) {
-        await extractFromPDF(f);
+        await extractFromPDF(f, fastMode);
     }
 
     // unique services
@@ -429,7 +432,7 @@ async function generatePDF() {
 
 
     //  qr page
-    if (qrEntries.length) {
+    if (!fastMode && qrEntries.length) {
         const qrSize = 70;
         const barcodeW = 100;
         const barcodeH = 20;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a checked Fast mode checkbox near the manifest generation controls
- Thread the Fast mode setting into PDF extraction
- Skip QR extraction and Tracking/POD page generation when Fast mode is enabled

## Testing
- Not run: Node.js is not installed in this environment (`node --check script.js` failed with `node: command not found`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4ecd3ca-e480-4fa5-972e-ce11b6f00a82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4ecd3ca-e480-4fa5-972e-ce11b6f00a82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

