### PR TITLE
Extract unique DN order numbers after successful merge

### DIFF
--- a/dn-extractor.js
+++ b/dn-extractor.js
@@ -1,0 +1,77 @@
+// dn-extractor.js
+//
+// Pure, UI-independent extraction of DN order numbers from the
+// "Order number, Reference no." column of the merged loading list.
+//
+// The extractor looks for values shaped like "DN 12345678" (case-insensitive,
+// optional whitespace between "DN" and the digits) and returns the captured
+// 8-digit numbers, de-duplicated while preserving first-occurrence order.
+//
+// Intentionally does not touch the DOM so it can be unit-tested in isolation
+// (see tests.html / tests/dn-extractor.test.js).
+
+(function (root, factory) {
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.DNExtractor = factory();
+    }
+}(typeof self !== 'undefined' ? self : this, function () {
+    // \bDN\s*(\d{8})\b, case-insensitive, global so we can find every match
+    // inside a single cell.
+    const DN_PATTERN = /\bDN\s*(\d{8})\b/gi;
+
+    function safeToString(value) {
+        if (value === null || value === undefined) return '';
+        try {
+            return String(value);
+        } catch (e) {
+            return '';
+        }
+    }
+
+    /**
+     * Extract unique 8-digit DN order numbers from an iterable of raw cell values.
+     *
+     * - Skips null / undefined / empty cells.
+     * - Coerces non-string values (numbers, objects, etc.) to strings safely.
+     * - Trims leading/trailing whitespace before matching.
+     * - Matches case-insensitively; multiple DN values inside one cell are all captured.
+     * - Preserves the order of the first occurrence and removes duplicates.
+     * - Ignores RF numbers, standalone 8-digit numbers, and numbers with a
+     *   different digit count.
+     *
+     * @param {Iterable<*>} values
+     * @returns {string[]} de-duplicated 8-digit numbers in first-occurrence order
+     */
+    function extractUniqueDNNumbers(values) {
+        const results = [];
+        const seen = new Set();
+
+        if (values === null || values === undefined) return results;
+        if (typeof values[Symbol.iterator] !== 'function') return results;
+
+        for (const value of values) {
+            const text = safeToString(value).trim();
+            if (!text) continue;
+
+            // Reset lastIndex defensively because DN_PATTERN is a shared, stateful /g regex.
+            DN_PATTERN.lastIndex = 0;
+            let match;
+            while ((match = DN_PATTERN.exec(text)) !== null) {
+                const number = match[1];
+                if (!seen.has(number)) {
+                    seen.add(number);
+                    results.push(number);
+                }
+            }
+        }
+
+        return results;
+    }
+
+    return {
+        DN_PATTERN,
+        extractUniqueDNNumbers
+    };
+}));

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
  <script defer src="https://unpkg.com/gsap@3.12.2/dist/gsap.min.js"></script>
  <script defer src="https://unpkg.com/gsap@3.12.2/dist/InertiaPlugin.min.js"></script>
  <script defer src="https://unpkg.com/@appletosolutions/reactbits/dist/reactbits.umd.js"></script>
+ <script defer src="dn-extractor.js"></script>
  <script defer src="script.js"></script>
 </head>
 <body>
@@ -56,6 +57,19 @@
      <button id="merge-btn">Generate Manifest PDF</button>
      <button id="remove-all-btn">Remove All</button>
    </div>
+
+   <section id="dn-section" aria-labelledby="dn-section-title">
+     <div id="dn-section-header">
+       <h2 id="dn-section-title">Extracted DN order numbers</h2>
+       <button type="button" id="dn-copy-btn" disabled>Copy all</button>
+     </div>
+     <textarea id="dn-output"
+               readonly
+               rows="8"
+               aria-label="Extracted DN order numbers"
+               placeholder="DN order numbers extracted from the merged loading list will appear here after a successful merge."></textarea>
+     <div id="dn-status" role="status" aria-live="polite"></div>
+   </section>
  </div>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -23,6 +23,11 @@ const COL_WIDTHS = [50, 60, 80, 70, 90, 130, 70, 110, 45, 75];
 const TABLE_W = COL_WIDTHS.reduce((a, b) => a + b, 0);
 const VALID_CODES = [];
 
+// Column index of "Order number, Reference no." in COL_HEADERS / data.rows[i].
+// Used by the DN order-number extraction to pull the right column out of the
+// processed merged data (not by re-reading the generated PDF).
+const ORDER_NUMBER_COL_IDX = 2;
+
 let pdfFiles = [];
 let qrEntries = [];
 let transportEntries = [];
@@ -35,6 +40,12 @@ const fileList = document.getElementById('file-list');
 const mergeBtn = document.getElementById('merge-btn');
 const removeAllBtn = document.getElementById('remove-all-btn');
 const outputFilename = document.getElementById('outputFilename');
+
+// DN order-number extraction UI
+const dnOutput = document.getElementById('dn-output');
+const dnCopyBtn = document.getElementById('dn-copy-btn');
+const dnStatus = document.getElementById('dn-status');
+let dnStatusResetTimer = null;
 
 dropArea.addEventListener('dragover', e => {
     e.preventDefault();
@@ -105,6 +116,117 @@ function hideOverlay() {
     document.getElementById('loader-overlay').classList.remove('show');
 }
 
+// ── DN order-number UI helpers ───────────────────────────────────────────
+// The extraction logic itself lives in dn-extractor.js. These helpers only
+// deal with reflecting extraction results in the DOM.
+
+function setDNStatus(message, tone) {
+    if (!dnStatus) return;
+    dnStatus.textContent = message || '';
+    dnStatus.classList.remove('error', 'success');
+    if (tone === 'error') dnStatus.classList.add('error');
+    if (tone === 'success') dnStatus.classList.add('success');
+}
+
+function clearDNSection() {
+    if (dnStatusResetTimer) {
+        clearTimeout(dnStatusResetTimer);
+        dnStatusResetTimer = null;
+    }
+    if (dnOutput) dnOutput.value = '';
+    if (dnCopyBtn) {
+        dnCopyBtn.disabled = true;
+        dnCopyBtn.textContent = 'Copy all';
+        dnCopyBtn.classList.remove('copied');
+    }
+    setDNStatus('');
+}
+
+function renderDNNumbers(numbers) {
+    if (!dnOutput) return;
+    const list = Array.isArray(numbers) ? numbers : [];
+    dnOutput.value = list.join('\n');
+    if (dnCopyBtn) {
+        dnCopyBtn.disabled = list.length === 0;
+        dnCopyBtn.textContent = 'Copy all';
+        dnCopyBtn.classList.remove('copied');
+    }
+    if (list.length === 0) {
+        setDNStatus('No DN order numbers found.');
+    } else {
+        setDNStatus(`${list.length} unique DN order number${list.length === 1 ? '' : 's'} extracted.`);
+    }
+}
+
+function runDNExtractionFromRows(rows) {
+    try {
+        if (!window.DNExtractor || typeof window.DNExtractor.extractUniqueDNNumbers !== 'function') {
+            console.warn('DNExtractor is not available; skipping DN order-number extraction.');
+            setDNStatus('DN extraction unavailable.', 'error');
+            return;
+        }
+        const values = (rows || []).map(r => (r && r.length > ORDER_NUMBER_COL_IDX) ? r[ORDER_NUMBER_COL_IDX] : '');
+        const numbers = window.DNExtractor.extractUniqueDNNumbers(values);
+        renderDNNumbers(numbers);
+    } catch (err) {
+        console.error('Failed to extract DN order numbers:', err);
+        setDNStatus('Failed to extract DN order numbers. See console for details.', 'error');
+    }
+}
+
+async function copyDNNumbersToClipboard() {
+    if (!dnOutput || !dnCopyBtn || dnCopyBtn.disabled) return;
+    const text = dnOutput.value;
+    if (!text) return;
+
+    const showCopied = () => {
+        dnCopyBtn.textContent = 'Copied';
+        dnCopyBtn.classList.add('copied');
+        setDNStatus('Copied to clipboard.', 'success');
+        if (dnStatusResetTimer) clearTimeout(dnStatusResetTimer);
+        dnStatusResetTimer = setTimeout(() => {
+            dnCopyBtn.textContent = 'Copy all';
+            dnCopyBtn.classList.remove('copied');
+            // Restore the neutral "N unique DN order numbers extracted." message
+            // once the transient "Copied" feedback disappears.
+            const count = text.split('\n').filter(Boolean).length;
+            setDNStatus(`${count} unique DN order number${count === 1 ? '' : 's'} extracted.`);
+        }, 1800);
+    };
+
+    try {
+        if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+            await navigator.clipboard.writeText(text);
+            showCopied();
+            return;
+        }
+    } catch (err) {
+        console.warn('navigator.clipboard.writeText failed, falling back to execCommand:', err);
+    }
+
+    // Fallback for older browsers / non-secure contexts.
+    try {
+        const prevSelectionStart = dnOutput.selectionStart;
+        const prevSelectionEnd = dnOutput.selectionEnd;
+        dnOutput.focus();
+        dnOutput.select();
+        const ok = document.execCommand && document.execCommand('copy');
+        dnOutput.setSelectionRange(prevSelectionStart, prevSelectionEnd);
+        if (ok) {
+            showCopied();
+        } else {
+            setDNStatus('Copy failed. Please copy manually.', 'error');
+        }
+    } catch (err) {
+        console.error('Fallback clipboard copy failed:', err);
+        setDNStatus('Copy failed. Please copy manually.', 'error');
+    }
+}
+
+if (dnCopyBtn) {
+    dnCopyBtn.addEventListener('click', copyDNNumbersToClipboard);
+}
+
 mergeBtn.addEventListener('click', async () => {
     if (!pdfFiles.length) {
         return alert('Please select PDF files first.');
@@ -112,11 +234,21 @@ mergeBtn.addEventListener('click', async () => {
     const dt = new DataTransfer();
     pdfFiles.forEach(f => dt.items.add(f));
     fileInput.files = dt.files;
+    // Clear any previous DN extraction results before starting a new merge so
+    // stale data cannot linger if this merge fails or produces no matches.
+    clearDNSection();
     showOverlay();
+    let mergeSucceeded = false;
     try {
         await generatePDF();
+        mergeSucceeded = true;
     } finally {
         hideOverlay();
+    }
+    if (mergeSucceeded) {
+        // Extraction runs only after a successful merge, and is defensively
+        // wrapped so any failure here cannot break the merge / file-save flow.
+        runDNExtractionFromRows(data && data.rows);
     }
 });
 

--- a/style.css
+++ b/style.css
@@ -173,6 +173,95 @@ h1 {
  color: #ffffff;
 }
 
+/* DN EXTRACTION SECTION */
+#dn-section {
+ width: 100%;
+ max-width: 800px;
+ margin: 0 auto 2rem;
+ padding: 1rem 1.25rem;
+ background: #ffffff;
+ border-radius: 12px;
+ box-shadow: 0 6px 20px rgba(0, 59, 113, 0.1);
+}
+
+#dn-section-header {
+ display: flex;
+ align-items: center;
+ justify-content: space-between;
+ gap: 1rem;
+ margin-bottom: 0.75rem;
+}
+
+#dn-section-title {
+ margin: 0;
+ font-size: 1.05rem;
+ color: #003b71;
+ font-weight: 700;
+}
+
+#dn-copy-btn {
+ padding: 0.4rem 0.9rem;
+ border: none;
+ border-radius: 6px;
+ cursor: pointer;
+ font-size: 0.9rem;
+ font-weight: 600;
+ color: #ffffff;
+ background: linear-gradient(169deg, #1c73c4 0%, #1666b1 100%);
+ transition: transform 0.1s, box-shadow 0.1s, opacity 0.1s;
+}
+
+#dn-copy-btn:hover:not(:disabled) {
+ transform: translateY(-1px);
+ box-shadow: 0 4px 10px rgba(0, 115, 207, 0.3);
+}
+
+#dn-copy-btn:disabled {
+ opacity: 0.5;
+ cursor: not-allowed;
+}
+
+#dn-copy-btn.copied {
+ background: linear-gradient(169deg, #2ea44f 0%, #1f7a3a 100%);
+}
+
+#dn-output {
+ display: block;
+ width: 100%;
+ box-sizing: border-box;
+ min-height: 140px;
+ padding: 0.6rem 0.75rem;
+ border: 1px solid #c9d6e2;
+ border-radius: 6px;
+ font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+ font-size: 0.95rem;
+ line-height: 1.35;
+ background: #f9fbfd;
+ color: #1f2a44;
+ resize: vertical;
+}
+
+#dn-output:focus {
+ outline: none;
+ border-color: #1c73c4;
+ box-shadow: 0 0 0 3px rgba(0, 115, 207, 0.15);
+}
+
+#dn-status {
+ margin-top: 0.5rem;
+ min-height: 1.2em;
+ font-size: 0.85rem;
+ color: #506680;
+}
+
+#dn-status.error {
+ color: #b3261e;
+}
+
+#dn-status.success {
+ color: #1f7a3a;
+}
+
 /* SORT STATES */
 .sortable-ghost {
  opacity: 0.3 !important;

--- a/tests.html
+++ b/tests.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Manifest Merger – DN Extractor tests</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background: #f7f9fc;
+      color: #1f2a44;
+      margin: 0;
+      padding: 2rem;
+    }
+    h1 {
+      color: #003b71;
+      margin-top: 0;
+    }
+    #summary {
+      font-weight: 700;
+      margin: 1rem 0;
+    }
+    #summary.ok { color: #1f7a3a; }
+    #summary.fail { color: #b3261e; }
+    ol {
+      background: #ffffff;
+      border-radius: 8px;
+      padding: 1rem 1rem 1rem 2.5rem;
+      box-shadow: 0 4px 12px rgba(0, 59, 113, 0.08);
+    }
+    li { margin: 0.25rem 0; }
+    li.pass { color: #1f7a3a; }
+    li.fail { color: #b3261e; }
+    .err {
+      display: block;
+      font-family: monospace;
+      background: #fff5f5;
+      color: #7a1a13;
+      padding: 0.4rem 0.6rem;
+      margin-top: 0.25rem;
+      border-radius: 4px;
+      white-space: pre-wrap;
+    }
+  </style>
+</head>
+<body>
+  <h1>DN Extractor tests</h1>
+  <div id="summary">Running…</div>
+  <ol id="results"></ol>
+
+  <script>
+    window.__renderDNExtractorTestResults = function (summary) {
+      const summaryEl = document.getElementById('summary');
+      const list = document.getElementById('results');
+      summaryEl.textContent =
+        summary.passed + '/' + summary.total + ' passed, ' + summary.failed + ' failed.';
+      summaryEl.className = summary.failed === 0 ? 'ok' : 'fail';
+      list.innerHTML = '';
+      for (const r of summary.results) {
+        const li = document.createElement('li');
+        li.className = r.passed ? 'pass' : 'fail';
+        li.textContent = (r.passed ? 'PASS' : 'FAIL') + ' — ' + r.name;
+        if (!r.passed) {
+          const err = document.createElement('span');
+          err.className = 'err';
+          err.textContent = r.error;
+          li.appendChild(err);
+        }
+        list.appendChild(li);
+      }
+    };
+  </script>
+  <script src="dn-extractor.js"></script>
+  <script src="tests/dn-extractor.test.js"></script>
+</body>
+</html>

--- a/tests/dn-extractor.test.js
+++ b/tests/dn-extractor.test.js
@@ -1,0 +1,233 @@
+// Tests for dn-extractor.js
+//
+// Runs both in Node (`node tests/dn-extractor.test.js`) and in the browser
+// via tests.html. No external test framework so the project stays dependency-
+// free and consistent with its "open the HTML file" workflow.
+
+(function (root) {
+    const isNode = typeof module === 'object' && module.exports;
+    const DNExtractor = isNode
+        ? require('../dn-extractor.js')
+        : root.DNExtractor;
+
+    if (!DNExtractor || typeof DNExtractor.extractUniqueDNNumbers !== 'function') {
+        throw new Error('DNExtractor is not available; make sure dn-extractor.js is loaded first.');
+    }
+
+    const { extractUniqueDNNumbers } = DNExtractor;
+    const results = [];
+
+    function arraysEqual(a, b) {
+        if (!Array.isArray(a) || !Array.isArray(b)) return false;
+        if (a.length !== b.length) return false;
+        for (let i = 0; i < a.length; i++) {
+            if (a[i] !== b[i]) return false;
+        }
+        return true;
+    }
+
+    function test(name, fn) {
+        try {
+            fn();
+            results.push({ name, passed: true });
+        } catch (err) {
+            results.push({ name, passed: false, error: err && err.message ? err.message : String(err) });
+        }
+    }
+
+    function assertEqualArray(actual, expected, label) {
+        if (!arraysEqual(actual, expected)) {
+            throw new Error(
+                (label ? label + ': ' : '') +
+                'expected [' + expected.join(', ') + '] but got [' + (Array.isArray(actual) ? actual.join(', ') : String(actual)) + ']'
+            );
+        }
+    }
+
+    // ── 1. Normal DN values with a space ────────────────────────────────
+    test('extracts normal "DN <space> 8 digits" values', () => {
+        assertEqualArray(
+            extractUniqueDNNumbers(['DN 57109142', 'DN 57110459']),
+            ['57109142', '57110459']
+        );
+    });
+
+    // ── 2. DN with and without a space ──────────────────────────────────
+    test('accepts DN with or without whitespace between prefix and digits', () => {
+        assertEqualArray(
+            extractUniqueDNNumbers(['DN57109142', 'DN   57110459', 'DN\t57120277']),
+            ['57109142', '57110459', '57120277']
+        );
+    });
+
+    // ── 3. Lowercase / mixed-case dn ────────────────────────────────────
+    test('is case-insensitive (dn / Dn / dN all match)', () => {
+        assertEqualArray(
+            extractUniqueDNNumbers(['dn 57109142', 'Dn 57110459', 'dN57120277']),
+            ['57109142', '57110459', '57120277']
+        );
+    });
+
+    // ── 4. Duplicate DN values ──────────────────────────────────────────
+    test('removes duplicates across cells', () => {
+        assertEqualArray(
+            extractUniqueDNNumbers(['DN 57109142', 'DN 57109142', 'dn 57109142']),
+            ['57109142']
+        );
+    });
+
+    // ── 5. RF values are ignored ────────────────────────────────────────
+    test('ignores RF-prefixed order numbers', () => {
+        assertEqualArray(
+            extractUniqueDNNumbers(['RF 57120277', 'RF57109142', 'rf 57110459']),
+            []
+        );
+    });
+
+    // ── 6. Standalone 8-digit numbers are ignored ───────────────────────
+    test('ignores standalone 8-digit numbers with no DN prefix', () => {
+        assertEqualArray(
+            extractUniqueDNNumbers(['57109142', ' 57110459 ', '10164032']),
+            []
+        );
+    });
+
+    // ── 7. Empty and null cells ─────────────────────────────────────────
+    test('safely skips null, undefined, empty, and whitespace-only cells', () => {
+        assertEqualArray(
+            extractUniqueDNNumbers([null, undefined, '', '   ', '\t\n', 'DN 57109142']),
+            ['57109142']
+        );
+    });
+
+    // ── 8. Multiple DN values inside a single cell ──────────────────────
+    test('captures multiple DN values inside a single cell', () => {
+        assertEqualArray(
+            extractUniqueDNNumbers(['DN 57109142 DN 57110459 dn57120277']),
+            ['57109142', '57110459', '57120277']
+        );
+    });
+
+    // ── 9. First-occurrence order is preserved ──────────────────────────
+    test('preserves first-occurrence order when removing duplicates', () => {
+        assertEqualArray(
+            extractUniqueDNNumbers([
+                'DN 57109142',
+                '57110459',
+                'DN 57110459',
+                'DN 57109913',
+                '57109913',
+                'DN 57111844',
+                'DN 57111844',
+                'DN 57108666',
+                '57108666',
+                'DN 57108862',
+                'DN 57108862',
+                '10164032',
+                'RF 57120277',
+                'DN 57120277',
+                'DN 57120277',
+                'DN 57114963',
+                '57123667',
+                'DN 57123667',
+                '57116344',
+                'DN 57116344'
+            ]),
+            [
+                '57109142',
+                '57110459',
+                '57109913',
+                '57111844',
+                '57108666',
+                '57108862',
+                '57120277',
+                '57114963',
+                '57123667',
+                '57116344'
+            ]
+        );
+    });
+
+    // ── 10. Wrong digit counts are ignored ──────────────────────────────
+    test('ignores DN with fewer or more than 8 digits', () => {
+        assertEqualArray(
+            extractUniqueDNNumbers([
+                'DN 1234567',      // 7 digits
+                'DN 123456789',    // 9 digits
+                'DN 5710914',      // 7 digits
+                'DN 571091423'     // 9 digits
+            ]),
+            []
+        );
+    });
+
+    // ── 11. Wrong digit counts alongside a valid one ────────────────────
+    test('extracts only the valid 8-digit DN when mixed with invalid ones', () => {
+        assertEqualArray(
+            extractUniqueDNNumbers(['DN 1234567 DN 57109142 DN 123456789']),
+            ['57109142']
+        );
+    });
+
+    // ── 12. Mixed data types coerced safely ─────────────────────────────
+    test('coerces non-string values safely', () => {
+        assertEqualArray(
+            extractUniqueDNNumbers([
+                57109142,                       // plain number, no DN → ignored
+                { toString: () => 'DN 57110459' },
+                ['DN 57120277']                 // Array#toString → "DN 57120277"
+            ]),
+            ['57110459', '57120277']
+        );
+    });
+
+    // ── 13. Non-iterable / bad inputs ───────────────────────────────────
+    test('returns [] for null / undefined / non-iterable inputs', () => {
+        assertEqualArray(extractUniqueDNNumbers(null), []);
+        assertEqualArray(extractUniqueDNNumbers(undefined), []);
+        assertEqualArray(extractUniqueDNNumbers(12345), []);
+    });
+
+    // ── 14. Leading/trailing whitespace ─────────────────────────────────
+    test('trims leading and trailing whitespace before matching', () => {
+        assertEqualArray(
+            extractUniqueDNNumbers(['   DN 57109142   ', '\n\tDN 57110459\n']),
+            ['57109142', '57110459']
+        );
+    });
+
+    // ── 15. Join produces exactly the UI-facing value ───────────────────
+    test('joined output has no blank lines and no duplicates', () => {
+        const numbers = extractUniqueDNNumbers([
+            'DN 57109142', '', null, 'DN 57109142', 'DN 57110459', '   '
+        ]);
+        const joined = numbers.join('\n');
+        if (joined !== '57109142\n57110459') {
+            throw new Error('unexpected joined output: ' + JSON.stringify(joined));
+        }
+        if (joined.split('\n').some(line => line === '')) {
+            throw new Error('joined output contains blank lines');
+        }
+    });
+
+    const summary = {
+        total: results.length,
+        passed: results.filter(r => r.passed).length,
+        failed: results.filter(r => !r.passed).length,
+        results
+    };
+
+    if (isNode) {
+        for (const r of results) {
+            const tag = r.passed ? 'PASS' : 'FAIL';
+            console.log(`  [${tag}] ${r.name}${r.passed ? '' : '\n         ' + r.error}`);
+        }
+        console.log(`\n${summary.passed}/${summary.total} passed, ${summary.failed} failed.`);
+        if (summary.failed > 0) process.exit(1);
+    } else {
+        root.__DN_EXTRACTOR_TEST_RESULTS__ = summary;
+        if (typeof root.__renderDNExtractorTestResults === 'function') {
+            root.__renderDNExtractorTestResults(summary);
+        }
+    }
+}(typeof self !== 'undefined' ? self : this));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After a merged Loading List PDF is generated successfully, the app now extracts every unique 8-digit **DN order number** from the processed *"Order number, Reference no."* column and displays them in a new read-only section under the existing controls, with a **Copy all** button.

Extraction is done against the in-memory row data (`data.rows[i][2]`) — not by re-parsing the generated PDF — so it does **not** modify the document contents and cannot delay or break the merge / file-save flow.

## Files changed

- **`dn-extractor.js`** *(new)* — Pure, UI-independent module exporting `extractUniqueDNNumbers(values)` and `DN_PATTERN`. UMD-style export so it can be used both from the browser (attaches to `window.DNExtractor`) and from Node (for tests).
- **`index.html`** — Loads `dn-extractor.js` before `script.js` and adds a new `<section id="dn-section">` with a labelled `<h2>`, a read-only `<textarea id="dn-output">`, a `<button id="dn-copy-btn">Copy all</button>`, and a `<div id="dn-status" role="status" aria-live="polite">` for non-blocking feedback.
- **`style.css`** — Styling for the new section, matching the existing card / gradient-button visual language (white card, blue gradient button, monospace textarea, subtle status colors).
- **`script.js`** —
  - New `ORDER_NUMBER_COL_IDX = 2` named constant so the "Order number, Reference no." column is referenced by name.
  - New UI helpers: `setDNStatus`, `clearDNSection`, `renderDNNumbers`, `runDNExtractionFromRows`, `copyDNNumbersToClipboard` (all separate from the extraction logic itself).
  - `mergeBtn` click handler now calls `clearDNSection()` at the start of every merge and, only if `generatePDF()` completes without throwing, calls `runDNExtractionFromRows(data.rows)`.
- **`tests/dn-extractor.test.js`** *(new)* — Dependency-free test suite that runs in both Node and the browser.
- **`tests.html`** *(new)* — Tiny browser harness that renders the test results.

## Where extraction is triggered

Inside the `#merge-btn` click handler (`script.js`):

1. If the user has selected any PDFs, `clearDNSection()` is called before starting.
2. `generatePDF()` runs inside a `try` block; only if it completes without throwing is `mergeSucceeded` set.
3. After the `finally` that hides the loader overlay, `runDNExtractionFromRows(data.rows)` runs only when `mergeSucceeded === true`.
4. That helper safely pulls the 2nd column out of every row, feeds it to `DNExtractor.extractUniqueDNNumbers`, and renders the result.

Both the extraction and the clipboard code are wrapped in `try / catch` blocks and log via `console.error` / `console.warn`, so a failure in either path cannot affect the existing merge or file download.

## Duplicates and ordering

Handled entirely inside `extractUniqueDNNumbers` (`dn-extractor.js`):

- A stateful global `/g` regex (`\bDN\s*(\d{8})\b`, case-insensitive) is `exec`ed against each cell so multiple DN values per cell are captured.
- A `Set` (`seen`) is used **only for duplicate detection**; the captured 8-digit string is pushed onto an ordered `results` array the first time it is seen. This guarantees first-occurrence order is preserved and matches the task's worked example exactly.
- The UI-facing value is `numbers.join('\n')` — no bullets, no commas, no blank lines (empty / null cells are skipped upstream), and no duplicates.

## What is (and isn't) matched

- Case-insensitive: `DN 57109142`, `dn57109142`, `Dn\t57110459` all match.
- Must be surrounded by word boundaries and be exactly 8 digits — `DN 1234567`, `DN 123456789`, `abcDN 57109142def` are all ignored.
- `RF …`, standalone `57109142`, and values from unrelated columns are ignored.
- Null, undefined, empty string, whitespace-only string, numbers, and objects with `.toString` are handled safely.

## Manual testing steps

1. Open `index.html` in Chrome / Edge.
2. Drop in one or more real manifest PDFs.
3. Click **Generate Manifest PDF**.
4. Once the merged PDF downloads, scroll down: the *"Extracted DN order numbers"* section should be populated with one 8-digit number per line, in first-occurrence order, no duplicates.
5. If there are no DN numbers in the source manifests, the textarea stays empty and the status line reads *"No DN order numbers found."*
6. Click **Copy all** — the button briefly changes to **Copied**, the status line reads *"Copied to clipboard."*, and pasting elsewhere yields the exact newline-separated content.
7. Click **Generate Manifest PDF** again with a different set of PDFs → the section is cleared before the merge starts and re-populated with the new results afterwards.
8. Open `tests.html` in a browser (or run `node tests/dn-extractor.test.js`) — all 15 unit tests should pass.

## Test results

```
15/15 passed, 0 failed.
```

Covers: normal DN values, DN with/without whitespace, lowercase `dn`, duplicates, RF ignored, standalone numbers ignored, empty / null cells, multiple DN values per cell, first-occurrence order (using the task's exact example), wrong digit counts ignored, non-string values coerced safely, non-iterable inputs, whitespace trimming, and the joined output containing no blank lines or duplicates.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f47b6-4f7f-7783-ace4-968c131c9fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f47b6-4f7f-7783-ace4-968c131c9fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

